### PR TITLE
Defect & UX audit fixes (5 functional, 4 UX)

### DIFF
--- a/charmui.go
+++ b/charmui.go
@@ -540,20 +540,22 @@ func newCharmPterm() *charmPterm {
 	ui.Info = &MessagePrinter{
 		Prefix:           Prefix{Text: "INFO", Style: ui.NewStyle(ui.BgBlue, ui.FgWhite)},
 		style:            lipgloss.NewStyle(),
-		IncludeTimestamp: true, // Add timestamp to INFO logs
+		IncludeTimestamp: true,
 	}
 	ui.Warning = &MessagePrinter{
-		Prefix: Prefix{Text: "WARN", Style: ui.NewStyle(ui.BgYellow, ui.FgBlack)},
-		style:  lipgloss.NewStyle(),
+		Prefix:           Prefix{Text: "WARN", Style: ui.NewStyle(ui.BgYellow, ui.FgBlack)},
+		style:            lipgloss.NewStyle(),
+		IncludeTimestamp: true,
 	}
 	ui.Error = &MessagePrinter{
 		Prefix:           Prefix{Text: "ERROR", Style: ui.NewStyle(ui.BgRed, ui.FgWhite)},
 		style:            lipgloss.NewStyle(),
-		IncludeTimestamp: true, // Add timestamp to ERROR logs
+		IncludeTimestamp: true,
 	}
 	ui.Success = &MessagePrinter{
-		Prefix: Prefix{Text: "SUCCESS", Style: ui.NewStyle(ui.BgGreen, ui.FgBlack)},
-		style:  lipgloss.NewStyle(),
+		Prefix:           Prefix{Text: "SUCCESS", Style: ui.NewStyle(ui.BgGreen, ui.FgBlack)},
+		style:            lipgloss.NewStyle(),
+		IncludeTimestamp: true,
 	}
 
 	ui.DefaultSection = SectionPrinter{Style: ui.NewStyle(ui.FgCyan, ui.Bold)}

--- a/connect3270/emulator.go
+++ b/connect3270/emulator.go
@@ -856,27 +856,34 @@ func (e *Emulator) AsciiScreenGrab(filePath string, apiMode bool) error {
 				content += "</body></html>"
 			}
 
-			// Open or create the file for appending or overwriting
-			file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
-			if err != nil {
-				log.Printf("Error opening or creating file: %v", err)
+			if err := writeScreenGrab(filePath, content); err != nil {
 				return err
 			}
-
-			// Write the content to the file
-			if _, err := file.WriteString(content); err != nil {
-				log.Printf("Error writing to file: %v", err)
-				file.Close() // Ensure the file is closed in case of an error
-				return err
-			}
-
-			file.Close() // Ensure the file is properly closed
 			return nil
 		}
 		time.Sleep(retryDelay)
 	}
 
 	return fmt.Errorf("maximum capture retries reached")
+}
+
+func writeScreenGrab(filePath, content string) (err error) {
+	file, err := os.OpenFile(filePath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0644)
+	if err != nil {
+		log.Printf("Error opening or creating file: %v", err)
+		return err
+	}
+	defer func() {
+		if closeErr := file.Close(); closeErr != nil && err == nil {
+			log.Printf("Error closing file: %v", closeErr)
+			err = closeErr
+		}
+	}()
+	if _, err = file.WriteString(content); err != nil {
+		log.Printf("Error writing to file: %v", err)
+		return err
+	}
+	return nil
 }
 
 // ReadOutputFile reads the contents of the specified HTML file and returns it as a string.

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -629,13 +629,13 @@ func init() {
 	}
 
 	if err := os.MkdirAll("logs", 0755); err != nil {
-		pterm.Error.Println("Failed to create logs dir - universe says no:", err)
+		pterm.Error.Println("Failed to create logs directory:", err)
 	}
 
 	var err error
 	dashboardTemplate, err = template.ParseFS(dashboardTemplateFS, "templates/dashboard.gohtml")
 	if err != nil {
-		pterm.Error.Println("Dashboard template parsing went kaput:", err)
+		pterm.Error.Println("Failed to parse dashboard template:", err)
 	} else {
 		//pterm.Success.Println("Dashboard template loaded - ready to rock!")
 	}
@@ -666,7 +666,7 @@ func storeLog(message string) {
 
 	encoder := json.NewEncoder(file)
 	if err := encoder.Encode(logEntry); err != nil {
-		pterm.Error.Println("Log encoding broke - computers hate me:", err)
+		pterm.Error.Println("Failed to encode logs:", err)
 	}
 }
 
@@ -1025,7 +1025,7 @@ func runWorkflowWithEmulator(e *connect3270.Emulator, config *Configuration, ove
 		}
 	}()
 	if err := e.InitializeOutput(tmpFileName, runAPI); err != nil {
-		return handleError(err, fmt.Sprintf("Output init failed - setup's cursed: %v", err))
+		return handleError(err, fmt.Sprintf("Failed to initialize output: %v", err))
 	}
 	workflowFailed := false
 	connectFailed := false
@@ -1034,7 +1034,7 @@ func runWorkflowWithEmulator(e *connect3270.Emulator, config *Configuration, ove
 	if config.InputFilePath != "" {
 		steps, err = loadInputFile(config.InputFilePath)
 		if err != nil {
-			return handleError(err, fmt.Sprintf("Input file load crashed - file has gone rogue: %v\n", err))
+			return handleError(err, fmt.Sprintf("Failed to load input file: %v\n", err))
 		}
 	} else {
 		steps = config.Steps
@@ -1265,7 +1265,7 @@ func runAPIWorkflow() {
 		}
 		tmpFile, err := os.CreateTemp("", "workflowOutput_")
 		if err != nil {
-			pterm.Error.Println("Temp file creation failed - disk’s napping:", err)
+			pterm.Error.Println("Failed to create temporary file:", err)
 			sendErrorResponse(c, http.StatusInternalServerError, "Failed to create temp file", err)
 			return
 		}
@@ -1280,7 +1280,7 @@ func runAPIWorkflow() {
 		e := connect3270.NewEmulator(workflowConfig.Host, workflowConfig.Port, strconv.Itoa(scriptPort))
 		err = e.InitializeOutput(tmpFileName, true)
 		if err != nil {
-			sendErrorResponse(c, http.StatusInternalServerError, "Output init failed - setup’s cursed", err)
+			sendErrorResponse(c, http.StatusInternalServerError, "Failed to initialize output", err)
 			return
 		}
 		connected := false
@@ -2515,7 +2515,7 @@ func isPortAvailable(port int) bool {
 	ln, err := net.Listen("tcp", addr)
 	if err != nil {
 		if connect3270.Verbose {
-			pterm.Info.Printf("Port %d in use - next contestant please!\n", port)
+			pterm.Info.Printf("Port %d in use\n", port)
 		}
 		return false
 	}

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -3514,7 +3514,12 @@ func startProcessHandler(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	tempFilePath := filepath.Join(os.TempDir(), handler.Filename)
+	safeConfigName := filepath.Base(handler.Filename)
+	if safeConfigName == "" || safeConfigName == "." || safeConfigName == string(filepath.Separator) {
+		http.Error(w, "Invalid configuration filename", http.StatusBadRequest)
+		return
+	}
+	tempFilePath := filepath.Join(os.TempDir(), safeConfigName)
 	if err := os.WriteFile(tempFilePath, updatedJSON, 0644); err != nil {
 		http.Error(w, "Failed to save file", http.StatusInternalServerError)
 		return
@@ -3525,7 +3530,12 @@ func startProcessHandler(w http.ResponseWriter, r *http.Request) {
 	injectionFile, injectionHandler, err := r.FormFile("injectionConfig")
 	if err == nil {
 		defer injectionFile.Close()
-		injectionConfigPath = filepath.Join(os.TempDir(), injectionHandler.Filename)
+		safeInjectionName := filepath.Base(injectionHandler.Filename)
+		if safeInjectionName == "" || safeInjectionName == "." || safeInjectionName == string(filepath.Separator) {
+			http.Error(w, "Invalid injection configuration filename", http.StatusBadRequest)
+			return
+		}
+		injectionConfigPath = filepath.Join(os.TempDir(), safeInjectionName)
 		injectionTempFile, err := os.Create(injectionConfigPath)
 		if err != nil {
 			http.Error(w, "Failed to save injection configuration file", http.StatusInternalServerError)

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -7,6 +7,7 @@ import (
 	"embed"
 	"encoding/binary"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"html/template"
@@ -1271,7 +1272,11 @@ func runAPIWorkflow() {
 		defer tmpFile.Close()
 		tmpFileName := tmpFile.Name()
 		defer os.Remove(tmpFileName)
-		scriptPort := getNextAvailablePort()
+		scriptPort, err := getNextAvailablePort()
+		if err != nil {
+			sendErrorResponse(c, http.StatusServiceUnavailable, "No script port available", err)
+			return
+		}
 		e := connect3270.NewEmulator(workflowConfig.Host, workflowConfig.Port, strconv.Itoa(scriptPort))
 		err = e.InitializeOutput(tmpFileName, true)
 		if err != nil {
@@ -1717,7 +1722,16 @@ func (w *workflowWorker) start() {
 			w.releaseInjectionLock(job.injectionIndex)
 			continue
 		}
-		scriptPort := getNextAvailablePort()
+		scriptPort, err := getNextAvailablePort()
+		if err != nil {
+			storeLog(fmt.Sprintf("Worker %d skipping workflow: %v", w.id, err))
+			if connect3270.Verbose {
+				pterm.Error.Printf("Worker %d skipping workflow: %v\n", w.id, err)
+			}
+			addError(fmt.Errorf("worker %d: %w", w.id, err))
+			w.releaseInjectionLock(job.injectionIndex)
+			continue
+		}
 		w.emulator.ScriptPort = strconv.Itoa(scriptPort)
 		if connect3270.Verbose {
 			storeLog(fmt.Sprintf("Worker %d using script port %d", w.id, scriptPort))
@@ -2460,29 +2474,39 @@ func clear() {
 	print("\033[H\033[2J")
 }
 
-func getNextAvailablePort() int {
-	mutex.Lock()
-	defer mutex.Unlock()
-	const maxPort = 65000
-	checked := 0
+var errPortRangeExhausted = errors.New("no available script port in configured range")
+
+func getNextAvailablePort() (int, error) {
+	const (
+		maxPort      = 65000
+		waitInterval = 100 * time.Millisecond
+		maxWait      = 30 * time.Second
+	)
+	deadline := time.Now().Add(maxWait)
 	for {
-		lastUsedPort++
-		if lastUsedPort > maxPort {
-			lastUsedPort = startPort
+		mutex.Lock()
+		checked := 0
+		rangeSize := maxPort - startPort + 1
+		for checked < rangeSize {
+			lastUsedPort++
+			if lastUsedPort > maxPort {
+				lastUsedPort = startPort
+			}
+			if isPortAvailable(lastUsedPort) {
+				port := lastUsedPort
+				mutex.Unlock()
+				return port, nil
+			}
+			checked++
+			if connect3270.Verbose {
+				pterm.Warning.Printf("Port %d in use, trying next\n", lastUsedPort)
+			}
 		}
-		if isPortAvailable(lastUsedPort) {
-			return lastUsedPort
+		mutex.Unlock()
+		if time.Now().After(deadline) {
+			return 0, errPortRangeExhausted
 		}
-		checked++
-		if connect3270.Verbose {
-			pterm.Warning.Printf("Port %d is taken - port party’s full!\n", lastUsedPort)
-		}
-		if checked >= (maxPort - startPort + 1) {
-			mutex.Unlock()
-			time.Sleep(100 * time.Millisecond)
-			mutex.Lock()
-			checked = 0
-		}
+		time.Sleep(waitInterval)
 	}
 }
 

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -3508,7 +3508,12 @@ func startProcessHandler(w http.ResponseWriter, r *http.Request) {
 		config.Port = portValue
 	}
 	if override := strings.TrimSpace(r.FormValue("overrideOutputFilePath")); override != "" {
-		config.OutputFilePath = override
+		cleaned := filepath.Clean(override)
+		if filepath.IsAbs(cleaned) || strings.HasPrefix(cleaned, ".."+string(filepath.Separator)) || cleaned == ".." {
+			http.Error(w, "overrideOutputFilePath must be a relative path within the working directory", http.StatusBadRequest)
+			return
+		}
+		config.OutputFilePath = cleaned
 	}
 	if override := strings.TrimSpace(r.FormValue("overrideRampUpBatchSize")); override != "" {
 		batchValue, convErr := strconv.Atoi(override)

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -3413,22 +3413,26 @@ func startProcessHandler(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Check for sample app parameters
-	runApp := r.FormValue("runApp")
+	runApp := strings.TrimSpace(r.FormValue("runApp"))
 	if runApp != "" {
 		storeLog("Sample app mode detected")
-		runAppPort := r.FormValue("runAppPort")
-		// Construct command for sample app mode
+		runAppPort := strings.TrimSpace(r.FormValue("runAppPort"))
+		if _, err := strconv.Atoi(runApp); err != nil {
+			http.Error(w, "Invalid runApp value", http.StatusBadRequest)
+			return
+		}
+		if port, err := strconv.Atoi(runAppPort); err != nil || port < 1 || port > 65535 {
+			http.Error(w, "Invalid runAppPort value", http.StatusBadRequest)
+			return
+		}
 		executablePath := getExecutablePath()
-		command := fmt.Sprintf("%s -runApp %s -runApp-port %s", executablePath, runApp, runAppPort)
+		args := []string{"-runApp", runApp, "-runApp-port", runAppPort}
 		go func() {
-			pterm.Info.Printf("Executing sample app command: %s\n", command)
-			storeLog("Executing sample app command: " + command)
-			// Adjust for OS differences if needed
-			commandParts := strings.Fields(command)
-			executable := commandParts[0]
-			args := commandParts[1:]
+			logLine := fmt.Sprintf("%s %s", executablePath, strings.Join(args, " "))
+			pterm.Info.Printf("Executing sample app command: %s\n", logLine)
+			storeLog("Executing sample app command: " + logLine)
 
-			cmd := exec.Command(executable, args...)
+			cmd := exec.Command(executablePath, args...)
 			cmd.Stdout = os.Stdout
 			cmd.Stderr = os.Stderr
 			if err := cmd.Run(); err != nil {

--- a/templates/dashboard.gohtml
+++ b/templates/dashboard.gohtml
@@ -521,9 +521,16 @@
       line-height: 1;
     }
 
-    .action-icon:hover {
+    .action-icon:hover,
+    .action-icon:focus-visible {
       transform: scale(1.1);
       color: var(--primary);
+    }
+
+    .action-icon:focus-visible {
+      outline: 2px solid var(--primary);
+      outline-offset: 3px;
+      border-radius: 2px;
     }
 
     .mainframe-footer {
@@ -872,15 +879,23 @@
       transition: all 0.2s ease;
     }
 
-    .action-icon:hover {
+    .action-icon:hover,
+    .action-icon:focus-visible {
       transform: scale(1.2);
+    }
+
+    .action-icon:focus-visible {
+      outline: 2px solid currentColor;
+      outline-offset: 3px;
+      border-radius: 2px;
     }
 
     .action-icon.logs {
       color: var(--primary);
     }
 
-    .action-icon.logs:hover {
+    .action-icon.logs:hover,
+    .action-icon.logs:focus-visible {
       text-shadow: 0 0 8px rgba(0, 255, 128, 0.5);
     }
 
@@ -888,7 +903,8 @@
       color: var(--destructive);
     }
 
-    .action-icon.kill:hover {
+    .action-icon.kill:hover,
+    .action-icon.kill:focus-visible {
       text-shadow: 0 0 8px rgba(255, 82, 82, 0.5);
     }
 
@@ -896,7 +912,8 @@
       color: #5bc0de;
     }
 
-    .action-icon.workflow:hover {
+    .action-icon.workflow:hover,
+    .action-icon.workflow:focus-visible {
       transform: scale(1.2);
       text-shadow: 0 0 8px rgba(91, 192, 222, 0.6);
     }
@@ -905,7 +922,8 @@
       color: #f0ad4e;
     }
 
-    .action-icon.output:hover {
+    .action-icon.output:hover,
+    .action-icon.output:focus-visible {
       transform: scale(1.2);
       text-shadow: 0 0 8px rgba(240, 173, 78, 0.6);
     }
@@ -914,7 +932,8 @@
       color: #17a2b8;
     }
 
-    .action-icon.summary:hover {
+    .action-icon.summary:hover,
+    .action-icon.summary:focus-visible {
       transform: scale(1.2);
       text-shadow: 0 0 8px rgba(23, 162, 184, 0.6);
     }

--- a/templates/dashboard.gohtml
+++ b/templates/dashboard.gohtml
@@ -512,6 +512,15 @@
       transition: transform 0.2s ease, color 0.2s ease;
     }
 
+    button.action-icon {
+      background: none;
+      border: 0;
+      padding: 0;
+      color: inherit;
+      font: inherit;
+      line-height: 1;
+    }
+
     .action-icon:hover {
       transform: scale(1.1);
       color: var(--primary);
@@ -1677,11 +1686,11 @@
         <div class="modal-header">
           <h5 class="modal-title" id="consoleModalLabel">Console Logs</h5>
           <div class="d-flex gap-2">
-            <button type="button" class="btn btn-sm btn-light" id="maximizeConsoleBtn" onclick="maximizeConsoleModal()" data-tippy-content="Maximize">
-              <i class="fas fa-expand"></i>
+            <button type="button" class="btn btn-sm btn-light" id="maximizeConsoleBtn" aria-label="Maximize console" onclick="maximizeConsoleModal()" data-tippy-content="Maximize">
+              <i class="fas fa-expand" aria-hidden="true"></i>
             </button>
-            <button type="button" class="btn btn-sm btn-light" id="restoreConsoleBtn" onclick="restoreConsoleModal()" style="display: none;" data-tippy-content="Restore">
-              <i class="fas fa-compress"></i>
+            <button type="button" class="btn btn-sm btn-light" id="restoreConsoleBtn" aria-label="Restore console size" onclick="restoreConsoleModal()" style="display: none;" data-tippy-content="Restore">
+              <i class="fas fa-compress" aria-hidden="true"></i>
             </button>
             <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
           </div>
@@ -2455,16 +2464,16 @@
       // Build action icons conditionally
       var actionIcons = '';
       if (showWorkflowButton) {
-        actionIcons += '<i class="fas fa-file-code action-icon workflow" onclick="showWorkflowModal(' + metric.pid + ')" data-tippy-content="View Workflow JSON"></i>';
+        actionIcons += '<button type="button" class="action-icon workflow" aria-label="View workflow JSON" onclick="showWorkflowModal(' + metric.pid + ')" data-tippy-content="View Workflow JSON"><i class="fas fa-file-code" aria-hidden="true"></i></button>';
       }
       if (hasOutputPath) {
-        actionIcons += '<i class="fas fa-desktop action-icon output" onclick="showOutputModal(' + metric.pid + ')" data-tippy-content="Preview Output HTML"></i>';
+        actionIcons += '<button type="button" class="action-icon output" aria-label="Preview output HTML" onclick="showOutputModal(' + metric.pid + ')" data-tippy-content="Preview Output HTML"><i class="fas fa-desktop" aria-hidden="true"></i></button>';
       }
       if (hasConfigPath && metric.status === "Ended") {
-        actionIcons += '<i class="fas fa-file-text action-icon summary" onclick="showSummaryModal(' + metric.pid + ')" data-tippy-content="View Performance Summary"></i>';
+        actionIcons += '<button type="button" class="action-icon summary" aria-label="View performance summary" onclick="showSummaryModal(' + metric.pid + ')" data-tippy-content="View Performance Summary"><i class="fas fa-file-text" aria-hidden="true"></i></button>';
       }
-      actionIcons += '<i class="fas fa-file-alt action-icon logs" onclick="openLogsModal(' + metric.pid + ')" data-tippy-content="View Logs"></i>';
-      actionIcons += '<i class="fas fa-skull-crossbones action-icon kill" onclick="confirmKill(' + metric.pid + ', \'' + (metric.params || '-dashboard') + '\')" data-tippy-content="Terminate Process"></i>';
+      actionIcons += '<button type="button" class="action-icon logs" aria-label="View logs" onclick="openLogsModal(' + metric.pid + ')" data-tippy-content="View Logs"><i class="fas fa-file-alt" aria-hidden="true"></i></button>';
+      actionIcons += '<button type="button" class="action-icon kill" aria-label="Terminate process" onclick="confirmKill(' + metric.pid + ', \'' + (metric.params || '-dashboard') + '\')" data-tippy-content="Terminate Process"><i class="fas fa-skull-crossbones" aria-hidden="true"></i></button>';
       
       var row = document.createElement("tr");
       row.innerHTML = `


### PR DESCRIPTION
## Summary

Implements the prioritised audit of `go3270Connect.go`, `connect3270/emulator.go`, `charmui.go`, and `templates/dashboard.gohtml`. Each fix is a separate commit so reviewers can take or revert them individually.

### Functional fixes
| # | Commit | What changed | Risk / follow-up |
|---|---|---|---|
| F1 | `fix: prevent argument injection in sample-app start handler` | `startProcessHandler` was concatenating `runApp`/`runAppPort` form values into a single string then re-splitting on whitespace — an attacker could inject `-dashboard -api-port 9999` and similar. Both values are now validated as integers (and port range-checked) and passed as discrete args. | Low. Narrows accepted input — any caller that relied on non-numeric values will now get HTTP 400. |
| F2 | `fix: sanitize uploaded filenames in start-process handler` | `filepath.Join(os.TempDir(), handler.Filename)` accepted `..`-laden filenames that escaped `os.TempDir()` and were then handed to `exec.Command` as `-config`. Stripped with `filepath.Base` and rejects empty/`.`/root results, for both the workflow config and the optional injection config. | Low. |
| F3 | `fix: bound getNextAvailablePort wait and propagate exhaustion errors` | Function unlocked the mutex inside a `defer Unlock` scope and slept indefinitely on port exhaustion, hanging concurrent load-test workers with no observable failure. Restructured as an outer retry loop with a 30s deadline returning `errPortRangeExhausted`; updated both call sites (workflow API handler and concurrent worker) to surface the error cleanly. | Medium — touches two call sites. Manual exhaustion test in the verification section below. |
| F4 | `fix: reject absolute and parent-escaping overrideOutputFilePath values` | Dashboard clients could specify an absolute or `..`-prefixed output path that the spawned workflow would write to. Now `filepath.Clean`-ed and rejected if absolute or escaping the working directory. | Low. |
| F5 | `fix: surface Close errors from AsciiScreenGrab writes` | Both `file.Close()` returns were dropped, so a failed flush would silently succeed. Extracted to a `writeScreenGrab` helper with deferred close and a named return that surfaces the close error when the write itself succeeded. | Low. Behavioral change is only that previously-hidden flush errors now propagate. |

### UX fixes
| # | Commit | What changed | Risk / follow-up |
|---|---|---|---|
| U1 | `style: rewrite informal error messages in sentence case` | Eight error/info log strings (e.g. "universe says no", "computers hate me", "file has gone rogue") rewritten in plain sentence case matching the rest of the operator log voice. | None. |
| U2 | `fix(a11y): render process-row action icons as real buttons` | The five process-row action icons (workflow, output, summary, logs, kill) and the console maximize/restore controls were `<i onclick>` tags — not focusable, not announced to screen readers, tooltip available only on hover. Now rendered as `<button type="button" aria-label="...">`, with the FontAwesome `<i>` marked `aria-hidden`, plus a `button.action-icon` CSS reset so the visual styling is unchanged. | Low. Visual sanity check on the dashboard recommended. |
| U3 | `fix(a11y): add focus-visible styling to action icons` | After U2 makes the icons focusable, the existing styles only defined `:hover`. Added `:focus-visible` mirroring the hover state plus a visible outline in both `.action-icon` CSS blocks (the panel and the process-row variants). | None. |
| U4 | `fix: timestamp WARN and SUCCESS log levels for consistency` | `INFO`/`ERROR` had `IncludeTimestamp: true` while `WARN`/`SUCCESS` did not, so operators couldn't time-order events. Enabled timestamps on all four levels. | None. |

### Decisions surfaced as questions, not auto-fixed
- **Footer tagline** (`templates/dashboard.gohtml:1665`): you opted to keep the existing copy as-is.

### Noted, not fixed (out of scope)
- `registerWorkflowStatus` / `updateWorkflowStatus` / `clearWorkflowStatus` (`go3270Connect.go:434-470`) use explicit `Lock`/`Unlock` instead of `defer` — panic-unsafe in theory, trivial bodies in practice.
- An empty `Steps` array silently registers a 0-step workflow that immediately clears; not a crash, just a no-op.
- Duplicate `.action-icon` CSS block exists at `dashboard.gohtml:509` and `:859`; worth deduplicating but counts as a refactor.

### Out of scope, intentionally not touched
- An earlier audit pass suggested a use-after-free in `sendScriptCommand` — investigated and ruled out; the function holds `scriptMu` for its full body.

## Test plan
- [x] `go build ./...` — clean.
- [x] `go vet ./...` — clean.
- [x] `go test ./...` — all packages pass.
- [ ] Manual: `./dist/3270Connect -dashboard -dashboardPort 8080`, tab through the process-row action buttons and confirm focus rings + screen-reader labels (U2/U3).
- [ ] Manual: upload a config with a name like `../../foo.json` and confirm HTTP 400 (F2).
- [ ] Manual: POST to start-process with `runApp=1 -dashboard` and confirm HTTP 400 (F1).
- [ ] Manual: configure a tiny port range and launch concurrent workers; confirm callers see a clean `errPortRangeExhausted` rather than hanging (F3).
- [ ] Manual: tail the log stream and confirm WARN and SUCCESS now show timestamps alongside INFO/ERROR (U4).

No new dependencies introduced.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gb3kgRF2P2fUrr9AQGt289)_