### PR TITLE
docs: surface Prometheus metrics, host profiler, and security hardening

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ Here are the key features of 3270Connect:
 - API mode for advanced automation.
 - AI Chat mode for screen reading, field entry, key presses, and chaos exploration with explicit approval or Auto Mode.
 - Runtime RSA token injection using the `-token` flag or API `Token` property, keeping one-time passwords out of workflow files.
+- Prometheus `/metrics` endpoint (`-promListen`) exposing connect/step timing histograms, workflow outcomes, and live worker count for fleet-scale monitoring.
+- One-shot host compatibility profiler (`-profile`) that writes a `CompatibilityProfile` JSON document — same schema as 3270Web — for cross-environment comparison and chaos mind-map diffs.
 - Running a 3270 sample application to assist with testing workflow features.
 
 ## Connection timeout and retries
@@ -56,10 +58,49 @@ Here are the key features of 3270Connect:
 - The `/testConnection` API endpoint that probes host reachability uses a 5-second TCP dial timeout when opening the socket to the TN3270 host.  
   Source: `go3270Connect.go`.
 
+## Metrics
+
+Enable the Prometheus listener with `-promListen <addr>`:
+
+```bash
+3270Connect -config workflow.json -concurrent 10 -runtime 300 -promListen :9091
+```
+
+Collectors:
+
+- `tn3270_connect_seconds` — histogram of TN3270 session establishment time.
+- `tn3270_step_seconds{action}` — histogram of per-step wall time.
+- `tn3270_workflow_total{result}` — `success` / `failure` / `connect_failed` counter.
+- `tn3270_concurrent_workers` — live worker gauge.
+
+See the [Metrics & Monitoring guide](https://3270.io/metrics/) for example queries and a Prometheus scrape config.
+
+## Host Compatibility Profiler
+
+Run a one-shot probe against a host and capture its negotiated terminal model, protocol options, capabilities, and timing:
+
+```bash
+3270Connect -profile -profileHost mvs01.example.com -profilePort 992 -profileTLS \
+            -profileOut mvs01.profile.json
+```
+
+The resulting `CompatibilityProfile` JSON document uses the same schema as 3270Web's `POST /profile` endpoint, so profiles produced by either tool can be diffed against each other (e.g. IBM z/OS vs Rocket Enterprise Server). See the [profiler guide](https://3270.io/host-profiler/) and the [schema reference](https://3270.io/compatibility-profile-schema/).
+
+## Security hardening
+
+Recent releases tightened input handling across the dashboard and API surfaces. User-facing guarantees:
+
+- Sample-app launch arguments are validated against an allow-list — no shell or argument injection via crafted process names.
+- Uploaded workflow filenames in the dashboard's `start-process` handler are sanitised; path separators and traversal sequences are rejected.
+- The dashboard rejects absolute or parent-escaping values for `overrideOutputFilePath`; outputs always land under the configured working directory.
+- `getNextAvailablePort` is bounded and propagates exhaustion errors instead of looping indefinitely under heavy concurrency.
+
 ## Documentation
 
 - [Documentation](https://3270.io)
 - [AI Chat Mode](https://3270.io/ai-chat-mode/)
+- [Metrics & Monitoring](https://3270.io/metrics/)
+- [Host Compatibility Profiler](https://3270.io/host-profiler/)
 
 ## License
 

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -108,3 +108,20 @@ docker run --rm -p 8080:8080 3270io/3270connect-windows:latest -api -api-port 80
 ### 3270Connect API Usage
 
 ![type:video](3270Connect_API_1_0_4_0.mp4){: style=''}
+
+### Metrics & Monitoring
+
+3270Connect can expose a Prometheus `/metrics` endpoint with histograms
+for connect and step timing, a counter partitioned by workflow outcome,
+and a live gauge of active workers. Enable it with `-promListen :9091`
+and scrape with the sample config in
+[Metrics & Monitoring](metrics.md).
+
+### Host Compatibility Profiler
+
+Run `3270Connect -profile -profileHost <host> -profilePort <port>` for a
+one-shot probe that writes a `CompatibilityProfile` JSON document. The
+document shares its schema with 3270Web's `POST /profile` endpoint, so
+the same JSON drops into 3270Web's chaos mind-map compare workflow for
+cross-environment diffing. See [Host Compatibility Profiler](host-profiler.md)
+and [Compatibility Profile Schema](compatibility-profile-schema.md).

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -22,6 +22,12 @@ To run a workflow, use the following command:
 - `-verboseFailures`: Emit concise failure-only logs (step, script port, error) without enabling full verbose mode-useful for high-concurrency runs where you only want failure diagnostics.
 - `-verboseScreenCaptureFailures`: When enabled alongside `-verboseFailures`, automatically captures the terminal screen as plain text whenever a workflow step fails or a WaitForField timeout occurs. Captures are limited to 5 total across all concurrent workflows to prevent disk exhaustion. Files are named using the format `failure_[scriptPort]_step[stepIndex]_[timestamp].txt` and saved in the current directory. The capture file path is included in the failure log message.
 - `-bar`: Enable compact progress bars and hide the live INFO rows. (Deprecated alias: `-enableProgressBar`.)
+- `-promListen <addr>`: Expose Prometheus metrics on `/metrics` at the given address (e.g. `:9091`). Disabled when empty. See [Metrics & Monitoring](metrics.md) for the collector list and example queries.
+- `-profile`: Run as a one-shot host compatibility profiler instead of executing the workflow. Connects, probes the host, writes a `CompatibilityProfile` JSON document, and exits. See [Host Compatibility Profiler](host-profiler.md).
+- `-profileHost <host>` / `-profilePort <port>`: Override the profile target. If omitted, the profiler reads `Host`/`Port` from `-config`.
+- `-profileTLS`: Mark the profiled host as TLS-protected in the output.
+- `-profileOut <path>`: Write the profile JSON to this path instead of stdout.
+- `-profileCollectRaw`: Include raw s3270 `Query` responses in the profile output.
 
 ### Injecting a runtime RSA token
 

--- a/docs/compatibility-profile-schema.md
+++ b/docs/compatibility-profile-schema.md
@@ -1,0 +1,128 @@
+# CompatibilityProfile schema (v1.0.0)
+
+The `CompatibilityProfile` JSON document is the shared output format
+produced by both `3270Web` (via the `internal/profiler` package, exposed
+as `POST /profile` and `POST /api/v1/sessions/:id/profile`) and
+`3270Connect` (via `3270Connect -profile`). Both repositories carry
+**identical bytes** of this document; bump in lock-step.
+
+## Versioning
+
+- `schema_version` follows semver. Breaking changes bump the major;
+  additive fields bump the minor.
+- **Consumers MUST tolerate unknown fields.** New fields can be added in
+  minor versions without breaking older readers.
+- Current: `1.0.0`.
+
+## Top-level fields
+
+| Field | Type | Notes |
+|---|---|---|
+| `schema_version` | string | Always `"1.0.0"` for this revision. |
+| `run_id` | string | Random opaque identifier; lets a fleet probe correlate logs. |
+| `timestamp` | RFC3339 UTC | When the probe ran. |
+| `profiler` | object | Tool metadata — see below. |
+| `host` | object | Network-side identity + first-screen fingerprint. |
+| `device` | object | Negotiated terminal model. |
+| `protocol` | object | TN3270 negotiation outcome. |
+| `capabilities` | object | Discovered capabilities + list of unanswered queries. |
+| `timing` | object | Connect / first-screen / keyboard-unlock latencies (ms). |
+| `raw` | object | Optional; raw s3270 `Query` responses keyed by query name. |
+
+### `profiler`
+
+```json
+{"tool": "3270Web" | "3270Connect", "version": "<semver>"}
+```
+
+### `host`
+
+```json
+{
+  "host": "mvs01.example.com",
+  "port": 992,
+  "tls": true,
+  "banner_signature": "<sha256 hex>",
+  "banner_preview": "first ~240 chars of first screen, normalised"
+}
+```
+
+- `banner_signature` is the sha256 of the first screen after collapsing
+  whitespace, stripping control characters, and ASCII-folding
+  non-printable codepoints. Two hosts that show the same logon banner
+  will have the same signature.
+- `host` and `port` are populated from `Query(Host)` when the host
+  answers, falling back to the caller-supplied identity otherwise.
+
+### `device`
+
+```json
+{
+  "terminal_type": "IBM-3279-2-E",
+  "rows": 24,
+  "cols": 80,
+  "color": true,
+  "extended_attributes": true,
+  "alt_screen": false
+}
+```
+
+### `protocol`
+
+```json
+{
+  "tn3270e": true,
+  "bind_image_present": true,
+  "structured_fields": true,
+  "lu_name": "LU01",
+  "negotiated_functions": ["BIND-IMAGE", "RESPONSES", "SYSREQ"]
+}
+```
+
+### `capabilities`
+
+```json
+{
+  "ind_file": "yes" | "no" | "unknown",
+  "query_reply_ids": ["..."],
+  "unknown": ["BindPluName", "Tn3270eFunctions"]
+}
+```
+
+- `ind_file` defaults to `"unknown"`. The mildly-destructive probe is
+  opt-in via the `ind_file_probe` request flag (3270Web) or
+  `-indFileProbe` (3270Connect — when added in a future slice).
+- `unknown` lists queries the host did not answer. This list is the
+  **primary signal** for spotting mainframe-vs-Rocket divergence: a
+  query present in one environment's `unknown` and absent from the
+  other's highlights a capability gap.
+
+### `timing`
+
+```json
+{"connect_ms": 142, "first_screen_ms": 38, "keyboard_unlock_ms": 38}
+```
+
+Zero indicates the value was not measured (e.g. the host does not expose
+connect timing).
+
+### `raw` (optional)
+
+```json
+{"Bind": "rows 24 cols 80 ...", "Model": "IBM-3279-2-E"}
+```
+
+Only emitted when the caller passes `collect_raw: true` (3270Web) or
+`-profileCollectRaw` (3270Connect). Useful for debugging parser drift
+against new s3270 versions.
+
+## Cross-environment comparison
+
+The canonical comparison key is the tuple
+`(device.terminal_type, host.banner_signature, protocol.tn3270e,
+protocol.structured_fields)`.
+
+Two profiles whose tuples match are compatible at the wire level even if
+their `capabilities.unknown` lists differ — the latter is a hint that
+the hosts implement different optional features (e.g. IND$FILE on z/OS
+but not on a stripped-down Rocket Enterprise Server image).

--- a/docs/host-profiler.md
+++ b/docs/host-profiler.md
@@ -1,0 +1,102 @@
+# Host Compatibility Profiler
+
+The `-profile` mode connects once to a TN3270 host, probes its
+negotiated terminal model, protocol options, and discovered
+capabilities, and writes a `CompatibilityProfile` JSON document. The
+schema is shared byte-for-byte with 3270Web, so profiles produced
+by either tool can be compared side-by-side (for example, to spot
+divergence between an IBM z/OS image and a stripped-down Rocket
+Enterprise Server stand-in).
+
+See [Compatibility Profile Schema](compatibility-profile-schema.md) for
+the full field reference.
+
+## Quick start
+
+```bash
+3270Connect -profile -profileHost mvs01.example.com -profilePort 992 -profileTLS \
+            -profileOut mvs01.profile.json
+```
+
+The probe connects, runs through s3270 `Query` requests against the host,
+captures the first screen's banner signature, records timing, and writes
+the JSON to `-profileOut` (or stdout when omitted). The process exits
+non-zero on failure so CI can fail fast.
+
+## Flags
+
+| Flag | Description |
+|---|---|
+| `-profile` | Enables one-shot profiler mode. Replaces the workflow runner for this invocation. |
+| `-profileHost <host>` | Host to profile. If omitted, falls back to `Host` in the workflow config. |
+| `-profilePort <port>` | Port to profile. If omitted, falls back to `Port` in the workflow config. |
+| `-profileTLS` | Mark the profiled host as TLS-protected in the output (`host.tls: true`). |
+| `-profileOut <path>` | Write the JSON to this path. When omitted, the document is emitted on stdout. |
+| `-profileCollectRaw` | Include raw s3270 `Query` responses in the `raw` block of the JSON. Useful for debugging parser drift against new s3270 versions. |
+
+The probe uses a 30-second total timeout for capability discovery and
+the standard 5-second TCP dial timeout for the initial connection.
+
+## Reusing a workflow config
+
+You can omit `-profileHost`/`-profilePort` and let the profiler pull
+them from `-config`:
+
+```bash
+3270Connect -profile -config workflow.json -profileOut current.profile.json
+```
+
+This makes it easy to drop `-profile` into an existing pipeline without
+duplicating connection metadata.
+
+## Example output
+
+```json
+{
+  "schema_version": "1.0.0",
+  "run_id": "8f3b2c1a...",
+  "timestamp": "2026-05-18T10:11:12Z",
+  "profiler": { "tool": "3270Connect", "version": "1.8.6" },
+  "host": {
+    "host": "mvs01.example.com",
+    "port": 992,
+    "tls": true,
+    "banner_signature": "9b6f...",
+    "banner_preview": "WELCOME TO MVS01 ..."
+  },
+  "device": {
+    "terminal_type": "IBM-3279-2-E",
+    "rows": 24,
+    "cols": 80,
+    "color": true,
+    "extended_attributes": true,
+    "alt_screen": false
+  },
+  "protocol": { "tn3270e": true, "bind_image_present": true, "structured_fields": true },
+  "capabilities": { "ind_file": "unknown", "query_reply_ids": ["..."], "unknown": [] },
+  "timing": { "connect_ms": 142, "first_screen_ms": 38, "keyboard_unlock_ms": 38 }
+}
+```
+
+## Cross-environment comparison
+
+Two profiles whose
+`(device.terminal_type, host.banner_signature, protocol.tn3270e, protocol.structured_fields)`
+tuples match are compatible at the wire level. Differences in
+`capabilities.unknown` highlight optional-feature gaps (e.g.
+IND$FILE on z/OS but not on a Rocket Enterprise Server image).
+
+3270Web ships a complementary
+**Chaos Mind-Map Compare** endpoint that visualises these differences
+across hosts — feed both profiles to its `POST /chaos/mindmap/compare`
+to get a divergence report.
+
+## When to use which
+
+- **`3270Connect -profile`** — CI/CD or shell-friendly one-shot probe.
+  No web UI needed; perfect for nightly fleet sweeps.
+- **3270Web `POST /profile`** — interactive use from the web UI or
+  programmatic use from automation that already talks to 3270Web.
+
+Both produce identical JSON; pick whichever fits the surrounding
+pipeline.

--- a/docs/index.md
+++ b/docs/index.md
@@ -38,6 +38,8 @@ Here are the key features of 3270Connect:
 - Verbose mode for detailed output, plus failure-only logging with `-verboseFailures` for high-concurrency test runs.
 - API mode for advanced automation.
 - AI Chat mode in 3270Web for screen reading, field entry, key presses, and chaos exploration with per-action approval or Auto Mode.
+- Prometheus metrics endpoint (`-promListen`) exposing connect/step timing, workflow outcomes, and live concurrency for fleet-scale monitoring.
+- One-shot host compatibility profiler (`-profile`) that produces a `CompatibilityProfile` JSON document shareable with 3270Web for cross-environment comparison.
 - Running a 3270 sample application to assist with testing workflow features.
 
 ## Getting Started
@@ -55,6 +57,9 @@ Once you've mastered the basics, you can dive into more advanced features:
 - [API Mode](advanced-features.md): Discover how to run 3270Connect as an API server for advanced automation and load performance testing.
 - [AI Chat Mode](ai-chat-mode.md): Use 3270Web to drive a live 3270 session through conversation, approve tool calls, and run chaos exploration.
 - [Chaos Mode](chaos-mode.md): Learn how toolbar controls and AI Chat share the same exploration state and export workflows.
+- [Metrics & Monitoring](metrics.md): Scrape `tn3270_connect_seconds`, `tn3270_step_seconds`, workflow outcomes, and live worker counts from `-promListen`.
+- [Host Compatibility Profiler](host-profiler.md): Probe a host once with `-profile` and write a `CompatibilityProfile` JSON document that compares cleanly against 3270Web output.
+- [Compatibility Profile Schema](compatibility-profile-schema.md): Field-by-field reference for the shared `CompatibilityProfile` document (v1.0.0).
 
 ## Conclusion
 

--- a/docs/metrics.md
+++ b/docs/metrics.md
@@ -1,0 +1,72 @@
+# Metrics & Monitoring
+
+3270Connect exposes Prometheus metrics for fleet-scale monitoring of
+workflow performance, concurrency, and outcome distribution. The metrics
+endpoint is opt-in and runs on a dedicated HTTP listener so it does not
+collide with the dashboard or API ports.
+
+## Enabling the `/metrics` endpoint
+
+Use the `-promListen` flag with any `host:port` address. Disabled when
+empty (the default).
+
+```bash
+3270Connect -config workflow.json -concurrent 10 -runtime 300 -promListen :9091
+```
+
+Once running, the metrics endpoint is available at:
+
+```
+http://localhost:9091/metrics
+```
+
+The listener uses a 5-second read-header timeout and runs in its own
+goroutine — failures are logged but never abort the workflow runner.
+
+## Collectors
+
+| Metric | Type | Labels | Meaning |
+|---|---|---|---|
+| `tn3270_connect_seconds` | Histogram | — | Wall-clock time to establish a TN3270 session (exponential buckets starting at 50 ms). |
+| `tn3270_step_seconds` | Histogram | `action` | Wall-clock time per workflow step, partitioned by step action (`Connect`, `FillString`, `CheckValue`, `PressEnter`, etc.). |
+| `tn3270_workflow_total` | Counter | `result` | Workflows that have terminated, partitioned by outcome: `success`, `failure`, `connect_failed`. |
+| `tn3270_concurrent_workers` | Gauge | — | Active workflow worker count. Useful for confirming that `-concurrent` ramps cleanly and never overshoots. |
+
+Source: [`internal/metrics/metrics.go`](https://github.com/3270io/3270Connect/blob/main/internal/metrics/metrics.go).
+
+## Sample scrape config
+
+Add a scrape job to `prometheus.yml`:
+
+```yaml
+scrape_configs:
+  - job_name: '3270connect'
+    scrape_interval: 15s
+    static_configs:
+      - targets: ['runner-01:9091', 'runner-02:9091']
+```
+
+## Useful queries
+
+```promql
+# p95 connect time over the last 5 minutes
+histogram_quantile(0.95, sum(rate(tn3270_connect_seconds_bucket[5m])) by (le))
+
+# Failure rate by outcome
+sum(rate(tn3270_workflow_total[1m])) by (result)
+
+# Slowest step actions (p95)
+histogram_quantile(0.95,
+  sum(rate(tn3270_step_seconds_bucket[5m])) by (le, action)
+)
+
+# Live worker count vs. configured concurrency
+tn3270_concurrent_workers
+```
+
+## Pairing with the host compatibility profiler
+
+For one-shot host fingerprinting (rather than continuous timing), use
+the [Host Compatibility Profiler](host-profiler.md) — the resulting
+`CompatibilityProfile` JSON is comparable to the one produced by
+3270Web and can be diffed across environments.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -63,6 +63,9 @@ nav:
   - Workflow Actions: workflow.md
   - Dynamic Field Injection: injection-config.md
   - Advanced Features: advanced-features.md
+  - Metrics & Monitoring: metrics.md
+  - Host Compatibility Profiler: host-profiler.md
+  - Compatibility Profile Schema: compatibility-profile-schema.md
   - Reference:
       - Build Guide: BUILD.md
       - Makefile Quick Reference: MAKEFILE_QUICKREF.md
@@ -106,7 +109,7 @@ extra_css:
   - stylesheets/extra.css
 
 extra:
-  version: 1.6
+  version: 1.8.6
   CNAME: 3270.io
   generator: false
   social:


### PR DESCRIPTION
## Summary

Surfaces three production-ready feature areas that already shipped in code but were missing from the user-facing docs.

- **Prometheus metrics** — new `docs/metrics.md` covers `-promListen` and all four collectors (`tn3270_connect_seconds`, `tn3270_step_seconds`, `tn3270_workflow_total`, `tn3270_concurrent_workers`) with example PromQL and a scrape config.
- **Host Compatibility Profiler** — new `docs/host-profiler.md` walks through `-profile` mode and every `-profileX` flag, with a worked example feeding 3270Web's chaos mind-map compare.
- **CompatibilityProfile schema (v1.0.0)** — new `docs/compatibility-profile-schema.md` lifts the shared schema out of `internal/profiler/SCHEMA.md` so docs readers do not have to dig through `internal/`.

### Other doc edits

- `README.md` gains Metrics, Host Compatibility Profiler, and a short Security hardening section covering recent argument-injection prevention, filename sanitisation, output-path traversal rejection, and the bounded `getNextAvailablePort` fix.
- `docs/index.md`, `docs/basic-usage.md`, and `docs/advanced-features.md` cross-link the new pages and surface the new flags in the flags reference.
- `mkdocs.yml` nav adds the three new pages and bumps `extra.version` from `1.6` → `1.8.6` to match `CLAUDE.md`.

## Test plan

- [x] `mkdocs build --strict` passes locally
- [x] All new internal links resolve
- [x] Nav entries appear under the existing Advanced Features grouping
- [ ] Reviewer eyeballs each new page end-to-end on the gh-pages preview after CI deploy

---
_Generated by [Claude Code](https://claude.ai/code/session_01NcyQnfkhKQxcYsRc8j4myN)_