### PR TITLE
Add host code page / character set selection (CodePage + -codePage)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -47,6 +47,7 @@ go test -v ./...
 | `-config` | Workflow JSON file (default: workflow.json) |
 | `-injectionConfig` | Dynamic field injection JSON |
 | `-token` | RSA token substitution |
+| `-codePage` | Host EBCDIC code page / charset (e.g. `cp037`, `cp278`/`finnish`); overrides workflow `CodePage`, passed to s3270 `-codepage` |
 | `-concurrent` | Number of parallel workflows (default: 1) |
 | `-runtime` | Max run duration in seconds |
 | `-api` / `-api-port` | REST API mode |
@@ -61,6 +62,7 @@ go test -v ./...
 {
   "Host": "mainframe.host",
   "Port": 3270,
+  "CodePage": "cp037",
   "EveryStepDelay": { "Min": 0.1, "Max": 0.3 },
   "WaitForField": true,
   "Steps": [

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Here are the key features of 3270Connect:
 - API mode for advanced automation.
 - AI Chat mode for screen reading, field entry, key presses, and chaos exploration with explicit approval or Auto Mode.
 - Runtime RSA token injection using the `-token` flag or API `Token` property, keeping one-time passwords out of workflow files.
+- Configurable host EBCDIC code page / character set via the workflow `CodePage` property or the `-codePage` flag (for example `cp037`, `cp285`, or `cp278`/`finnish`) so national and language-specific characters render correctly.
 - Prometheus `/metrics` endpoint (`-promListen`) exposing connect/step timing histograms, workflow outcomes, and live worker count for fleet-scale monitoring.
 - One-shot host compatibility profiler (`-profile`) that writes a `CompatibilityProfile` JSON document — same schema as 3270Web — for cross-environment comparison and chaos mind-map diffs.
 - Running a 3270 sample application to assist with testing workflow features.
@@ -57,6 +58,21 @@ Here are the key features of 3270Connect:
   Source: `go3270Connect.go`.
 - The `/testConnection` API endpoint that probes host reachability uses a 5-second TCP dial timeout when opening the socket to the TN3270 host.  
   Source: `go3270Connect.go`.
+
+## Host code page / character set
+
+3270 sessions exchange data in EBCDIC, so the correct national code page (host character set) must be selected for accented and language-specific characters to render correctly. Set it either in the workflow JSON with the `CodePage` property or on the command line with `-codePage` (the flag overrides the JSON value):
+
+```bash
+# Finnish/Swedish host (cp278)
+3270Connect -config workflow.json -codePage cp278
+```
+
+```json
+{ "Host": "mvs.example.com", "Port": 992, "CodePage": "cp278", "Steps": [ ... ] }
+```
+
+The value is passed straight to the embedded x3270/s3270 `-codepage` option, so any code page name (`cp037`), alias (`finnish`), or number (`278`) the emulator recognizes is accepted. When unset, the emulator default is used. In API mode the per-request `CodePage` property wins, falling back to the `-codePage` flag the server was started with. See the [Basic Usage guide](https://3270.io/basic-usage/#host-code-page-and-character-set) for the supported code page list.
 
 ## Metrics
 

--- a/connect3270/emulator.go
+++ b/connect3270/emulator.go
@@ -81,6 +81,11 @@ type Emulator struct {
 	Host       string
 	Port       int
 	ScriptPort string
+	// CodePage selects the host EBCDIC code page / character set for the
+	// session. When non-empty it is passed to the underlying x3270/s3270
+	// process via its -codepage option (e.g. "cp037", "cp285", "cp278" or
+	// the alias "finnish"). Empty leaves the emulator default in place.
+	CodePage string
 
 	scriptConn   net.Conn
 	scriptReader *bufio.Reader
@@ -618,6 +623,39 @@ func (e *Emulator) query(keyword string) (string, error) {
 	return e.execCommandOutput(command)
 }
 
+// buildEmulatorArgs assembles the command-line arguments for launching the
+// embedded x3270/s3270/wc3270 process. The argument order mirrors the
+// historical invocation so existing behavior is unchanged; the host EBCDIC
+// code page (-codepage) is inserted only when Emulator.CodePage is set, and
+// the host:port target is always the final positional argument.
+func (e *Emulator) buildEmulatorArgs(modelType string) []string {
+	resourceString := "x3270.unlockDelay: False"
+	if Headless {
+		resourceString = "s3270.unlockDelay: False"
+	} else if runtime.GOOS == "windows" {
+		resourceString = "wc3270.unlockDelay: False"
+	}
+
+	var args []string
+	if Headless {
+		args = []string{"-utf8", "-scriptport", e.ScriptPort, "-xrm", resourceString, "-model", modelType}
+	} else {
+		args = []string{"-utf8", "-xrm", resourceString, "-scriptport", e.ScriptPort, "-model", modelType}
+	}
+
+	// Host EBCDIC code page / character set (e.g. cp037, cp285, cp278). When
+	// unset, the emulator uses its built-in default code page.
+	if codePage := strings.TrimSpace(e.CodePage); codePage != "" {
+		args = append(args, "-codepage", codePage)
+		if Verbose {
+			log.Printf("Using host code page (-codepage %s) for %s", codePage, e.hostname())
+		}
+	}
+
+	args = append(args, e.hostname())
+	return args
+}
+
 // createApp creates a connection to the host using embedded x3270 or s3270
 func (e *Emulator) createApp() error {
 	if Verbose {
@@ -637,19 +675,7 @@ func (e *Emulator) createApp() error {
 	// Choose the correct model type
 	modelType := "3279-2" // Adjust this based on your application's requirements
 
-	var cmd *exec.Cmd
-	resourceString := "x3270.unlockDelay: False"
-	if Headless {
-		resourceString = "s3270.unlockDelay: False"
-	} else if runtime.GOOS == "windows" {
-		resourceString = "wc3270.unlockDelay: False"
-	}
-
-	if Headless {
-		cmd = exec.Command(binaryFilePath, "-utf8", "-scriptport", e.ScriptPort, "-xrm", resourceString, "-model", modelType, e.hostname())
-	} else {
-		cmd = exec.Command(binaryFilePath, "-utf8", "-xrm", resourceString, "-scriptport", e.ScriptPort, "-model", modelType, e.hostname())
-	}
+	cmd := exec.Command(binaryFilePath, e.buildEmulatorArgs(modelType)...)
 
 	if Verbose {
 		log.Printf("Executing command: %s %v", cmd.Path, cmd.Args)

--- a/connect3270/emulator_test.go
+++ b/connect3270/emulator_test.go
@@ -52,6 +52,97 @@ func TestPressResetKey(t *testing.T) {
 	}
 }
 
+// argIndex returns the index of target in args, or -1 if not present.
+func argIndex(args []string, target string) int {
+	for i, a := range args {
+		if a == target {
+			return i
+		}
+	}
+	return -1
+}
+
+// TestBuildEmulatorArgsOmitsCodePageWhenUnset verifies no -codepage option is
+// added when CodePage is empty, preserving the historical default behavior.
+func TestBuildEmulatorArgsOmitsCodePageWhenUnset(t *testing.T) {
+	prevHeadless := Headless
+	Headless = false
+	defer func() { Headless = prevHeadless }()
+
+	e := &Emulator{Host: "mvs.example.com", Port: 992, ScriptPort: "5000"}
+	args := e.buildEmulatorArgs("3279-2")
+
+	if argIndex(args, "-codepage") != -1 {
+		t.Fatalf("expected no -codepage when CodePage is empty, got args: %v", args)
+	}
+	if got := args[len(args)-1]; got != "mvs.example.com:992" {
+		t.Fatalf("expected hostname as last arg, got %q (args: %v)", got, args)
+	}
+}
+
+// TestBuildEmulatorArgsIncludesCodePage verifies -codepage <value> is inserted
+// immediately before the host:port positional argument when CodePage is set.
+func TestBuildEmulatorArgsIncludesCodePage(t *testing.T) {
+	prevHeadless := Headless
+	Headless = false
+	defer func() { Headless = prevHeadless }()
+
+	e := &Emulator{Host: "mvs.example.com", Port: 992, ScriptPort: "5000", CodePage: "cp278"}
+	args := e.buildEmulatorArgs("3279-2")
+
+	idx := argIndex(args, "-codepage")
+	if idx == -1 {
+		t.Fatalf("expected -codepage in args, got: %v", args)
+	}
+	if idx+1 >= len(args) || args[idx+1] != "cp278" {
+		t.Fatalf("expected -codepage followed by cp278, got: %v", args)
+	}
+	if got := args[len(args)-1]; got != "mvs.example.com:992" {
+		t.Fatalf("expected hostname as last arg, got %q (args: %v)", got, args)
+	}
+	// The code page value must sit immediately before the host:port argument.
+	if idx+1 != len(args)-2 {
+		t.Fatalf("expected -codepage value immediately before hostname, got: %v", args)
+	}
+}
+
+// TestBuildEmulatorArgsTrimsCodePage verifies surrounding whitespace is trimmed
+// from the configured code page before it is passed to the emulator.
+func TestBuildEmulatorArgsTrimsCodePage(t *testing.T) {
+	prevHeadless := Headless
+	Headless = false
+	defer func() { Headless = prevHeadless }()
+
+	e := &Emulator{Host: "h", Port: 23, ScriptPort: "5000", CodePage: "  finnish  "}
+	args := e.buildEmulatorArgs("3279-2")
+
+	idx := argIndex(args, "-codepage")
+	if idx == -1 || args[idx+1] != "finnish" {
+		t.Fatalf("expected trimmed -codepage finnish, got: %v", args)
+	}
+}
+
+// TestBuildEmulatorArgsHeadlessIncludesCodePage verifies the code page is also
+// honored in headless (s3270) mode while keeping the host as the final arg.
+func TestBuildEmulatorArgsHeadlessIncludesCodePage(t *testing.T) {
+	prevHeadless := Headless
+	Headless = true
+	defer func() { Headless = prevHeadless }()
+
+	e := &Emulator{Host: "h", Port: 23, ScriptPort: "5050", CodePage: "cp037"}
+	args := e.buildEmulatorArgs("3279-2")
+
+	if idx := argIndex(args, "-codepage"); idx == -1 || args[idx+1] != "cp037" {
+		t.Fatalf("expected -codepage cp037 in headless args, got: %v", args)
+	}
+	if argIndex(args, "-scriptport") == -1 {
+		t.Fatalf("expected -scriptport in headless args, got: %v", args)
+	}
+	if got := args[len(args)-1]; got != "h:23" {
+		t.Fatalf("expected hostname as last arg in headless mode, got %q (args: %v)", got, args)
+	}
+}
+
 // TestWaitForFieldErrorIncludesKeyboardLockDetail tests that WaitForField error
 // messages include KeyboardLockDetail information when retries are exhausted
 func TestWaitForFieldErrorIncludesKeyboardLockDetail(t *testing.T) {

--- a/docs/advanced-features.md
+++ b/docs/advanced-features.md
@@ -33,6 +33,7 @@ Body:
 {
   "Host": "10.27.27.27",
   "Port": 3270,
+  "CodePage": "cp037",
   "Token": "123456",
   "EveryStepDelay": { "Min": 0.1, "Max": 0.3 },
   "EndOfTaskDelay": { "Min": 30, "Max": 90 },
@@ -81,6 +82,7 @@ Body:
 The API responds with the rendered output in the JSON response body (it does not require an `OutputFilePath`).
 
 - `Token` (optional): provide a one-time RSA token that will be injected wherever the workflow text contains `{{token}}`.
+- `CodePage` (optional): host EBCDIC code page / character set for the session (for example `cp037`, `cp285`, or `cp278`/`finnish`). When omitted, the server falls back to the `-codePage` flag the API process was started with, and otherwise uses the emulator default. See [Host Code Page and Character Set](basic-usage.md#host-code-page-and-character-set).
 
 !!! note
 

--- a/docs/basic-usage.md
+++ b/docs/basic-usage.md
@@ -12,6 +12,7 @@ To run a workflow, use the following command:
 
 - `-config`: Specifies the path to the configuration file (default is "workflow.json").
 - `-token`: Provides a one-time RSA token that replaces any `{{token}}` placeholder in workflow step text during execution.
+- `-codePage`: Sets the host EBCDIC code page / character set for the 3270 session (for example `cp037`, `cp285`, or `cp278`/`finnish`). Overrides the workflow's `CodePage` value when supplied and is passed straight through to the embedded x3270/s3270 emulator's `-codepage` option. See [Host Code Page and Character Set](#host-code-page-and-character-set).
 - `-showConnectionErrors`: By default, connection failures for the `Connect` step are informational and do not increment the failed workflow counter. Set this flag to surface connection failures as errors and include them in the failure tally.
 - `WaitForField` (config, default `true`): When enabled, the workflow waits for the terminal to unlock an input field before each step after a successful `Connect`. Supports both simple boolean and detailed configuration:
   - Boolean format: `"WaitForField": true` or `"WaitForField": false` (uses defaults: 1s delay, 10 retries)
@@ -49,6 +50,7 @@ To run a single workflow, create a JSON configuration file that describes the wo
 {
   "Host": "10.27.27.62",
   "Port": 3270,
+  "CodePage": "cp037", // optional host code page / charset; omit to use the emulator default
   "EveryStepDelay": { "Min": 0.1, "Max": 0.3 },
   "WaitForField": true, // optional (default true) to wait before all steps once connected
   "OutputFilePath": "output.html", // optional; if omitted a temp file is used
@@ -223,6 +225,48 @@ Use it as follows:
 ```bash
 3270Connect -config workflow.json -startPort 5000
 ```
+
+### Host Code Page and Character Set
+
+Mainframe sessions exchange data in EBCDIC, and the correct national code page (also called the host character set) must be selected so that accented and language-specific characters render correctly. For example, Finnish/Swedish hosts commonly use code page **cp278**.
+
+You can set the code page in two ways:
+
+- **In the workflow JSON** with the top-level `CodePage` property:
+
+  ```json
+  {
+    "Host": "mvs.example.com",
+    "Port": 992,
+    "CodePage": "cp278",
+    "Steps": [ { "Type": "Connect" }, { "Type": "Disconnect" } ]
+  }
+  ```
+
+- **On the command line** with the `-codePage` flag, which overrides the value in the workflow JSON:
+
+  ```bash
+  3270Connect -config workflow.json -codePage cp278
+  ```
+
+The value is passed directly to the embedded x3270/s3270 emulator's `-codepage` option, so any code page name, alias, or number that the emulator recognizes is accepted. Leave `CodePage` unset (and omit `-codePage`) to use the emulator's built-in default code page.
+
+Common SBCS code pages (with aliases) supported by the bundled emulator:
+
+| Code page | Aliases | Region / language |
+|-----------|---------|-------------------|
+| `cp037` | `us`, `us-intl` | US / Canada (English) |
+| `cp273` | `german` | Germany / Austria |
+| `cp277` | `norwegian` | Denmark / Norway |
+| `cp278` | `finnish`, `swedish` | Finland / Sweden |
+| `cp280` | `italian` | Italy |
+| `cp284` | `spanish` | Spain / Latin America |
+| `cp285` | `uk` | United Kingdom |
+| `cp297` | `french` | France |
+| `cp500` | `belgian` | International / Belgium |
+| `cp1140`–`cp1149` | `*-euro` | Euro-symbol variants of the above |
+
+You can supply the canonical name (`cp278`), an alias (`finnish`), or the bare number (`278`). Run `s3270 -v` to print the full list of code pages compiled into the emulator. If an unrecognized code page is supplied, the emulator logs a warning and falls back to its default, so connectivity is not interrupted.
 
 ## Examples
 

--- a/docs/workflow.md
+++ b/docs/workflow.md
@@ -2,6 +2,23 @@
 
 This page provides an overview of the various workflow steps available in the 3270Connect application. Each step represents an individual action taken on the terminal during a workflow execution.
 
+## Connection Settings
+
+These top-level properties configure the terminal connection for the whole workflow:
+
+- **Host** (string): Hostname or IP address of the TN3270 host.
+- **Port** (int): TCP port of the TN3270 host.
+- **CodePage** (string, optional): Host EBCDIC code page / character set for the session, for example `cp037`, `cp285`, or `cp278`/`finnish`. When set, it is passed to the embedded x3270/s3270 emulator via its `-codepage` option so that national and language-specific characters render correctly. The `-codePage` CLI flag overrides this value. Leave it unset to use the emulator default. See [Host Code Page and Character Set](basic-usage.md#host-code-page-and-character-set) for the list of supported code pages.
+
+```json
+{
+  "Host": "mvs.example.com",
+  "Port": 992,
+  "CodePage": "cp278",
+  "Steps": [ { "Type": "Connect" }, { "Type": "Disconnect" } ]
+}
+```
+
 ## Delay Behavior
 
 You can control pacing with flexible delay ranges:

--- a/go3270Connect.go
+++ b/go3270Connect.go
@@ -125,8 +125,14 @@ func (w WaitForFieldConfig) MarshalJSON() ([]byte, error) {
 
 // Configuration holds the settings for the terminal connection and the steps to be executed.
 type Configuration struct {
-	Host            string
-	Port            int
+	Host string
+	Port int
+	// CodePage selects the host EBCDIC code page / character set for the 3270
+	// session (e.g. "cp037", "cp285", "cp278" or the alias "finnish"). It is
+	// passed to the underlying x3270/s3270 emulator via its -codepage option.
+	// Leave empty to use the emulator default. The -codePage CLI flag overrides
+	// this value when set.
+	CodePage        string             `json:"CodePage,omitempty"`
 	OutputFilePath  string             `json:"OutputFilePath"`
 	WaitForField    WaitForFieldConfig `json:"WaitForField,omitempty"`
 	Steps           []Step
@@ -293,6 +299,7 @@ var (
 	configFile                   string
 	injectionConfig              string
 	rsaToken                     string
+	hostCodePage                 string
 	showHelp                     bool
 	runAPI                       bool
 	apiPort                      int
@@ -593,6 +600,7 @@ func init() {
 	flag.StringVar(&configFile, "config", "workflow.json", "Path to the configuration file")
 	flag.StringVar(&injectionConfig, "injectionConfig", "", "Path to the injection configuration file")
 	flag.StringVar(&rsaToken, "token", "", "RSA token value to substitute for {{token}} placeholders")
+	flag.StringVar(&hostCodePage, "codePage", "", "Host EBCDIC code page / character set for the 3270 session (e.g. cp037, cp285, cp278 or 'finnish'). Overrides the workflow 'CodePage' value and is passed to the x3270/s3270 -codepage option.")
 	flag.BoolVar(&showHelp, "help", false, "Show usage information")
 	flag.BoolVar(&runAPI, "api", false, "Run as API")
 	flag.IntVar(&apiPort, "api-port", 8080, "API port")
@@ -1004,6 +1012,7 @@ func runWorkflowWithEmulator(e *connect3270.Emulator, config *Configuration, ove
 	}()
 	e.Host = config.Host
 	e.Port = config.Port
+	e.CodePage = config.CodePage
 
 	// Always start from a clean session to avoid reusing stale emulator state between pooled runs.
 	_ = e.Disconnect()
@@ -1259,6 +1268,10 @@ func runAPIWorkflow() {
 		if workflowConfig.Token == "" && rsaToken != "" {
 			workflowConfig.Token = rsaToken
 		}
+		// Per-request CodePage wins; otherwise fall back to the -codePage CLI flag.
+		if strings.TrimSpace(workflowConfig.CodePage) == "" && strings.TrimSpace(hostCodePage) != "" {
+			workflowConfig.CodePage = strings.TrimSpace(hostCodePage)
+		}
 		if err := validateConfiguration(&workflowConfig); err != nil {
 			sendErrorResponse(c, http.StatusBadRequest, "Invalid workflow configuration", err)
 			return
@@ -1278,6 +1291,7 @@ func runAPIWorkflow() {
 			return
 		}
 		e := connect3270.NewEmulator(workflowConfig.Host, workflowConfig.Port, strconv.Itoa(scriptPort))
+		e.CodePage = workflowConfig.CodePage
 		err = e.InitializeOutput(tmpFileName, true)
 		if err != nil {
 			sendErrorResponse(c, http.StatusInternalServerError, "Failed to initialize output", err)
@@ -1574,6 +1588,10 @@ func main() {
 	metricsOutputFilePath = config.OutputFilePath
 	if rsaToken != "" {
 		config.Token = rsaToken
+	}
+	// The -codePage CLI flag overrides the workflow's CodePage when provided.
+	if strings.TrimSpace(hostCodePage) != "" {
+		config.CodePage = strings.TrimSpace(hostCodePage)
 	}
 	if !runAPI {
 		printWorkflowMetadata(configFile, config)

--- a/go3270Connect_test.go
+++ b/go3270Connect_test.go
@@ -250,6 +250,33 @@ func TestWaitForFieldConfigJSON(t *testing.T) {
 	}
 }
 
+func TestConfigurationCodePageJSON(t *testing.T) {
+	// CodePage is parsed from the workflow JSON.
+	data := `{"Host":"mvs.example.com","Port":992,"CodePage":"cp278","Steps":[]}`
+	var cfg Configuration
+	if err := json.Unmarshal([]byte(data), &cfg); err != nil {
+		t.Fatalf("failed to unmarshal CodePage: %v", err)
+	}
+	if cfg.CodePage != "cp278" {
+		t.Fatalf("expected CodePage cp278, got %q", cfg.CodePage)
+	}
+
+	// CodePage must survive the per-job struct copy used for concurrency/injection.
+	out := injectDynamicValues(&cfg, map[string]string{})
+	if out.CodePage != "cp278" {
+		t.Fatalf("expected CodePage to propagate via injectDynamicValues, got %q", out.CodePage)
+	}
+
+	// omitempty: an unset CodePage must not be emitted when marshaling.
+	b, err := json.Marshal(Configuration{Host: "h", Port: 23})
+	if err != nil {
+		t.Fatalf("failed to marshal configuration: %v", err)
+	}
+	if strings.Contains(string(b), "CodePage") {
+		t.Fatalf("expected empty CodePage to be omitted, got %s", string(b))
+	}
+}
+
 func TestInjectDynamicValuesWithUTF8Characters(t *testing.T) {
 	config := &Configuration{
 		Host: "localhost",

--- a/profile_mode.go
+++ b/profile_mode.go
@@ -44,8 +44,10 @@ func startPrometheusListener(addr string) {
 func runProfileMode() {
 	host := strings.TrimSpace(profileHost)
 	port := profilePort
+	// The -codePage CLI flag wins; otherwise fall back to the workflow config.
+	codePage := strings.TrimSpace(hostCodePage)
 
-	if host == "" || port == 0 {
+	if host == "" || port == 0 || codePage == "" {
 		// Fall back to the workflow config so callers can reuse their
 		// existing workflow.json instead of duplicating connection info.
 		if cfg, err := loadConfigurationSafe(configFile); err == nil && cfg != nil {
@@ -54,6 +56,9 @@ func runProfileMode() {
 			}
 			if port == 0 {
 				port = cfg.Port
+			}
+			if codePage == "" {
+				codePage = strings.TrimSpace(cfg.CodePage)
 			}
 		}
 	}
@@ -67,6 +72,7 @@ func runProfileMode() {
 	}
 
 	e := connect3270.NewEmulator(host, port, scriptPort)
+	e.CodePage = codePage
 	defer func() { _ = e.Disconnect() }()
 
 	if err := e.Connect(); err != nil {


### PR DESCRIPTION
## Summary

Adds the ability to select the **host EBCDIC code page / character set** for a 3270 session, so national and language-specific characters render correctly (for example `cp278` / `finnish` for Finnish/Swedish hosts). The value can be set in the workflow JSON **and** on the command line, as requested.

The value is passed straight through to the embedded x3270/s3270 emulator's `-codepage` option (the bundled `s3270 v4.1ga10` accepts canonical names like `cp037`, aliases like `finnish`, and bare numbers like `278`). When unset, the emulator's built-in default is preserved — existing workflows are unaffected.

## What changed

**Core**
- `connect3270/emulator.go`: new `Emulator.CodePage` field. Command building moved into a testable `buildEmulatorArgs` helper that appends `-codepage <value>` only when set, keeping `host:port` as the final positional argument. Verbose mode logs the selected code page.
- `go3270Connect.go`:
  - New top-level `CodePage` workflow property (`Configuration.CodePage`, `omitempty`).
  - New `-codePage` CLI flag that **overrides** the workflow value.
  - Wired into every execution path: single workflow, concurrent workers (via the central `runWorkflowWithEmulator`), and the REST API. API requests may set `CodePage` per request, falling back to the `-codePage` the server was started with.
- `profile_mode.go`: the host profiler resolves the code page from `-codePage`, then the workflow config.

**Precedence:** `-codePage` flag > workflow/request `CodePage` > emulator default.

**Tests**
- `connect3270/emulator_test.go`: arg-building coverage — omitted when unset, inserted before host when set, whitespace trimmed, honored in headless mode.
- `go3270Connect_test.go`: `Configuration` JSON parse, propagation through `injectDynamicValues`, and `omitempty` behavior.

**Docs** (all updated)
- `docs/basic-usage.md` — `-codePage` flag, config example, and a new "Host Code Page and Character Set" section with a supported-code-page table.
- `docs/workflow.md` — Connection Settings section documenting `CodePage`.
- `docs/advanced-features.md` — API `CodePage` property.
- `README.md` — feature bullet + dedicated section.
- `CLAUDE.md` — flags table + config example.

## Test plan

- [x] `go build ./...`, `go vet ./...`, `go test ./...` all pass.
- [x] End-to-end against the bundled sample app (`-headless -verbose`), verifying the real `s3270` invocation:
  - JSON `CodePage: cp285` → `... -model 3279-2 -codepage cp285 127.0.0.1:3271`
  - JSON `cp285` + `-codePage cp037` → `-codepage cp037` (CLI override wins)
  - No code page set → no `-codepage` argument (default behavior preserved)

## Notes

- `s3270`/`x3270` emit a warning and fall back to their default if an unrecognized code page is supplied, so a typo won't break connectivity.
- The dashboard "Start Process" flow inherits this via the uploaded workflow config file; no UI field was added in this change.

https://claude.ai/code/session_01Ka2JNMeoN3YGE66cw4m1eq

---
_Generated by [Claude Code](https://claude.ai/code/session_01Ka2JNMeoN3YGE66cw4m1eq)_